### PR TITLE
승부예측 페이지 구현

### DIFF
--- a/app/domain/bet/components/Banner/index.tsx
+++ b/app/domain/bet/components/Banner/index.tsx
@@ -1,0 +1,14 @@
+import * as s from './style.css';
+
+const Banner = () => {
+  return (
+    <div className={s.Container}>
+      <div>배너배너</div>
+      <div className={s.ButtonWrapper}>
+        <button className={s.ButtonStyle({ type: 'primary' })}>더 알아보기</button>
+        <button className={s.ButtonStyle({ type: 'secondary' })}>내 예측 공유하기</button>
+      </div>
+    </div>
+  );
+};
+export default Banner;

--- a/app/domain/bet/components/Banner/style.css.ts
+++ b/app/domain/bet/components/Banner/style.css.ts
@@ -1,0 +1,43 @@
+import { vars } from '@/root.css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const Container = style({
+  height: '10.625rem',
+  flexShrink: 0,
+  background:
+    'linear-gradient(0deg, rgba(18, 18, 18, 0.15) 0%, rgba(18, 18, 18, 0.00) 42.96%), linear-gradient(90deg, rgba(76, 14, 176, 0.40) -12.75%, rgba(76, 14, 176, 0.24) 113.73%)',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1.235rem',
+});
+
+export const ButtonWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.375rem',
+});
+
+export const ButtonStyle = recipe({
+  base: {
+    padding: '0.5rem 1rem',
+    borderRadius: '6.1875rem',
+    color: '#FFF',
+    fontSize: '0.875rem',
+    letterSpacing: '-0.035rem',
+  },
+  variants: {
+    type: {
+      primary: {
+        background: vars.color['white-15'],
+        fontWeight: 500,
+      },
+      secondary: {
+        background: 'linear-gradient(90deg, rgba(134, 0, 240, 0.80) -12.75%, rgba(70, 0, 183, 0.80) 113.73%)',
+        fontWeight: 700,
+      },
+    },
+  },
+});

--- a/app/domain/bet/components/PredictionBottomBar/index.tsx
+++ b/app/domain/bet/components/PredictionBottomBar/index.tsx
@@ -9,18 +9,35 @@ interface Props {
 }
 const PredictionBottomBar = ({ curSport, handleNav }: Props) => {
   const endIndex = SportArray.length - 1;
+
+  const canGoPrev = curSport !== SportArray[0].id;
+  const canGoNext = curSport !== SportArray[endIndex].id;
   return (
     <div className={s.Container}>
-      <button className={s.NavButton} onClick={() => handleNav(SportArray[SportsToIndexMap[curSport] - 1].id)}>
-        {curSport !== SportArray[0].id && (
+      <button
+        className={s.NavButton}
+        onClick={() => {
+          if (canGoPrev) {
+            handleNav(SportArray[SportsToIndexMap[curSport] - 1].id);
+          }
+        }}
+      >
+        {canGoPrev && (
           <>
             <Icon.SportNavArrow />
             {SportArray[SportsToIndexMap[curSport] - 1].value}
           </>
         )}
       </button>
-      <button className={s.NavButton} onClick={() => handleNav(SportArray[SportsToIndexMap[curSport] + 1].id)}>
-        {curSport !== SportArray[endIndex].id && (
+      <button
+        className={s.NavButton}
+        onClick={() => {
+          if (canGoNext) {
+            handleNav(SportArray[SportsToIndexMap[curSport] + 1].id);
+          }
+        }}
+      >
+        {canGoNext && (
           <>
             {SportArray[SportsToIndexMap[curSport] + 1].value}
             <Icon.SportNavArrow rotate={180} />

--- a/app/domain/bet/components/PredictionBottomBar/index.tsx
+++ b/app/domain/bet/components/PredictionBottomBar/index.tsx
@@ -1,0 +1,33 @@
+import { SportArray, SportsToIndexMap, type SportType } from '@/lib/types';
+
+import * as s from './style.css';
+import Icon from '@/lib/assets/icons';
+
+interface Props {
+  curSport: SportType;
+  handleNav: (sport: SportType) => void;
+}
+const PredictionBottomBar = ({ curSport, handleNav }: Props) => {
+  const endIndex = SportArray.length - 1;
+  return (
+    <div className={s.Container}>
+      <button className={s.NavButton} onClick={() => handleNav(SportArray[SportsToIndexMap[curSport] - 1].id)}>
+        {curSport !== SportArray[0].id && (
+          <>
+            <Icon.SportNavArrow />
+            {SportArray[SportsToIndexMap[curSport] - 1].value}
+          </>
+        )}
+      </button>
+      <button className={s.NavButton} onClick={() => handleNav(SportArray[SportsToIndexMap[curSport] + 1].id)}>
+        {curSport !== SportArray[endIndex].id && (
+          <>
+            {SportArray[SportsToIndexMap[curSport] + 1].value}
+            <Icon.SportNavArrow rotate={180} />
+          </>
+        )}
+      </button>
+    </div>
+  );
+};
+export default PredictionBottomBar;

--- a/app/domain/bet/components/PredictionBottomBar/style.css.ts
+++ b/app/domain/bet/components/PredictionBottomBar/style.css.ts
@@ -1,0 +1,24 @@
+import { vars } from '@/root.css';
+import { style } from '@vanilla-extract/css';
+
+export const Container = style({
+  width: '100%',
+  height: '4.75rem',
+  padding: '1.25rem',
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+  flexShrink: 0,
+  background: vars.color['bg-3'],
+});
+
+export const NavButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  color: vars.color['white-87'],
+  fontSize: '0.9375rem',
+  fontWeight: 700,
+  lineHeight: 1.2,
+  letterSpacing: '-0.0375rem',
+});

--- a/app/domain/bet/components/PredictionContents/index.tsx
+++ b/app/domain/bet/components/PredictionContents/index.tsx
@@ -1,0 +1,6 @@
+import * as s from './style.css';
+
+const PredictionContents = () => {
+  return <div className={s.Container}></div>;
+};
+export default PredictionContents;

--- a/app/domain/bet/components/PredictionContents/style.css.ts
+++ b/app/domain/bet/components/PredictionContents/style.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const Container = style({
+  width: '100%',
+  height: '100%',
+  flexGrow: 1,
+});

--- a/app/domain/bet/components/SportNav/SportSelector.tsx
+++ b/app/domain/bet/components/SportNav/SportSelector.tsx
@@ -1,0 +1,18 @@
+import type { PropsWithChildren } from 'react';
+import { motion } from 'motion/react';
+
+import * as s from './style.css';
+
+interface Props extends PropsWithChildren {
+  isSelected: boolean;
+  onClick: () => void;
+}
+const SportSelector = ({ children, isSelected, onClick }: Props) => {
+  return (
+    <button className={s.SportSelector({ isSelected })} onClick={onClick}>
+      {children}
+      {isSelected && <motion.div layoutId="sport-selector-underbar" className={s.UnderBar} />}
+    </button>
+  );
+};
+export default SportSelector;

--- a/app/domain/bet/components/SportNav/index.tsx
+++ b/app/domain/bet/components/SportNav/index.tsx
@@ -1,0 +1,21 @@
+import SportSelector from '@/domain/bet/components/SportNav/SportSelector';
+import { SportArray, type SportType } from '@/lib/types';
+
+import * as s from './style.css';
+
+interface Props {
+  curSport: SportType;
+  setSport: (sport: SportType) => void;
+}
+const SportNav = ({ curSport, setSport }: Props) => {
+  return (
+    <div className={s.Container}>
+      {SportArray.map((sport) => (
+        <SportSelector key={sport.id} isSelected={curSport === sport.id} onClick={() => setSport(sport.id)}>
+          {sport.value}
+        </SportSelector>
+      ))}
+    </div>
+  );
+};
+export default SportNav;

--- a/app/domain/bet/components/SportNav/style.css.ts
+++ b/app/domain/bet/components/SportNav/style.css.ts
@@ -1,0 +1,46 @@
+import { vars } from '@/root.css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const Container = style({
+  width: '100%',
+
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+
+  padding: '0.75rem 1.25rem',
+  background:
+    'linear-gradient(90deg, rgba(76, 14, 176, 0.40) -12.75%, rgba(76, 14, 176, 0.24) 113.73%), linear-gradient(0deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0.05) 100%), #121212',
+});
+
+export const SportSelector = recipe({
+  base: {
+    position: 'relative',
+    fontSize: '1rem',
+    fontWeight: 500,
+    lineHeight: 1.2,
+    letterSpacing: '-0.04rem',
+    transition: 'color 0.2s ease-in-out',
+  },
+  variants: {
+    isSelected: {
+      true: {
+        color: vars.color['white-87'],
+      },
+      false: {
+        color: vars.color['white-38'],
+      },
+    },
+  },
+});
+export const UnderBar = style({
+  position: 'absolute',
+  bottom: '-0.75rem',
+  left: 0,
+  right: 0,
+  height: '0.125rem',
+  background: vars.color['white-87'],
+  borderTopLeftRadius: '0.125rem',
+  borderTopRightRadius: '0.125rem',
+});

--- a/app/lib/assets/icons/SportNavArrow.tsx
+++ b/app/lib/assets/icons/SportNavArrow.tsx
@@ -1,0 +1,35 @@
+interface Props {
+  rotate?: number;
+}
+const SportNavArrow = ({ rotate = 0 }: Props) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      fill="none"
+      viewBox="0 0 20 20"
+      style={{ transform: `rotate(${rotate}deg)` }}
+    >
+      <mask
+        id="mask0_684_3025"
+        width="20"
+        height="20"
+        x="0"
+        y="0"
+        maskUnits="userSpaceOnUse"
+        style={{ maskType: 'alpha' }}
+      >
+        <path fill="#D9D9D9" d="M0 0h20v20H0z"></path>
+      </mask>
+      <g mask="url(#mask0_684_3025)">
+        <path
+          fill="#fff"
+          fillOpacity="0.87"
+          d="m2.958 10 6.125 6.125a.96.96 0 0 1 .302.73q-.01.416-.322.728a1 1 0 0 1-.73.313 1 1 0 0 1-.729-.313l-6.416-6.395a1.7 1.7 0 0 1-.375-.563A1.7 1.7 0 0 1 .688 10q0-.312.125-.625.124-.312.375-.563l6.416-6.416a.98.98 0 0 1 .74-.302q.426.01.74.323a1 1 0 0 1 .312.729 1 1 0 0 1-.313.729z"
+        ></path>
+      </g>
+    </svg>
+  );
+};
+export default SportNavArrow;

--- a/app/lib/assets/icons/index.ts
+++ b/app/lib/assets/icons/index.ts
@@ -3,6 +3,7 @@ import { Check } from '@/lib/assets/icons/Check';
 import DropdownArrow from '@/lib/assets/icons/DropdownArrow';
 import Hamburger from '@/lib/assets/icons/Hamburger';
 import KakaoLogo from '@/lib/assets/icons/KakaoLogo';
+import SportNavArrow from '@/lib/assets/icons/SportNavArrow';
 import Ticket from '@/lib/assets/icons/Ticket';
 import TokyLogo from '@/lib/assets/icons/TokyLogo';
 
@@ -14,6 +15,7 @@ const Icon = {
   Hamburger,
   DropdownArrow,
   Check,
+  SportNavArrow,
 };
 
 export default Icon;

--- a/app/lib/types/index.ts
+++ b/app/lib/types/index.ts
@@ -1,16 +1,16 @@
 // TODO: value 값 정비
 export const SportArray = [
   {
+    id: '야구',
+    value: '야구',
+  },
+  {
     id: '축구',
     value: '축구',
   },
   {
     id: '농구',
     value: '농구',
-  },
-  {
-    id: '야구',
-    value: '야구',
   },
   {
     id: '럭비',

--- a/app/lib/types/index.ts
+++ b/app/lib/types/index.ts
@@ -30,6 +30,14 @@ export const SportsPathMap = {
   hockey: '아이스하키',
 } as const;
 
+export const SportsToIndexMap: Record<SportType, number> = {
+  야구: 0,
+  축구: 1,
+  농구: 2,
+  럭비: 3,
+  아이스하키: 4,
+};
+
 export const UniversityArray = ['고려대학교', '연세대학교'] as const;
 
 export type SportType = (typeof SportArray)[number]['id'];

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -5,5 +5,8 @@ export default [
   route('login', 'routes/LoginPage/index.tsx'),
   route('login/koreapas', 'routes/KoreapasLoginPage/index.tsx'),
   route('signup', 'routes/SignUpPage/index.tsx'),
-  layout('common/components/AuthGuard/index.tsx', [route('live/:sports', 'routes/LivePage/index.tsx')]),
+  layout('common/components/AuthGuard/index.tsx', [
+    route('live/:sports', 'routes/LivePage/index.tsx'),
+    route('prediction', 'routes/PredictionPage/index.tsx'),
+  ]),
 ] satisfies RouteConfig;

--- a/app/routes/PredictionPage/index.tsx
+++ b/app/routes/PredictionPage/index.tsx
@@ -1,8 +1,11 @@
 import MainTopBar from '@/common/components/MainTopBar';
 import NavBar from '@/common/components/NavBar';
+import PredictionBottomBar from '@/domain/bet/components/PredictionBottomBar';
+import PredictionContents from '@/domain/bet/components/PredictionContents';
 import SportNav from '@/domain/bet/components/SportNav';
 import type { SportType } from '@/lib/types';
 import { useSearchParams } from 'react-router';
+import * as s from './style.css';
 
 const PredictionPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -13,10 +16,12 @@ const PredictionPage = () => {
   };
 
   return (
-    <div>
+    <div className={s.Container}>
       <MainTopBar />
       <NavBar />
       <SportNav curSport={sport} setSport={setSport} />
+      <PredictionContents />
+      <PredictionBottomBar curSport={sport} handleNav={setSport} />
     </div>
   );
 };

--- a/app/routes/PredictionPage/index.tsx
+++ b/app/routes/PredictionPage/index.tsx
@@ -1,0 +1,23 @@
+import MainTopBar from '@/common/components/MainTopBar';
+import NavBar from '@/common/components/NavBar';
+import SportNav from '@/domain/bet/components/SportNav';
+import type { SportType } from '@/lib/types';
+import { useSearchParams } from 'react-router';
+
+const PredictionPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sport = (searchParams.get('sport') as SportType) || '야구';
+  const setSport = (sport: SportType) => {
+    searchParams.set('sport', sport);
+    setSearchParams(searchParams);
+  };
+
+  return (
+    <div>
+      <MainTopBar />
+      <NavBar />
+      <SportNav curSport={sport} setSport={setSport} />
+    </div>
+  );
+};
+export default PredictionPage;

--- a/app/routes/PredictionPage/index.tsx
+++ b/app/routes/PredictionPage/index.tsx
@@ -6,6 +6,7 @@ import SportNav from '@/domain/bet/components/SportNav';
 import type { SportType } from '@/lib/types';
 import { useSearchParams } from 'react-router';
 import * as s from './style.css';
+import Banner from '@/domain/bet/components/Banner';
 
 const PredictionPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -19,6 +20,7 @@ const PredictionPage = () => {
     <div className={s.Container}>
       <MainTopBar />
       <NavBar />
+      <Banner />
       <SportNav curSport={sport} setSport={setSport} />
       <PredictionContents />
       <PredictionBottomBar curSport={sport} handleNav={setSport} />

--- a/app/routes/PredictionPage/style.css.ts
+++ b/app/routes/PredictionPage/style.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css';
+
+export const Container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  width: '100%',
+});


### PR DESCRIPTION
- #23 

### 한거

- 페이지 라우트 파고
- 위쪽 스포츠 네비 바 만들고
- 아래쪽 스포츠 네비 바도 만들었어요
<img width="339" height="735" alt="Screenshot 2025-08-10 at 12 54 10 AM" src="https://github.com/user-attachments/assets/a3e9beb4-7d5a-400d-acdb-cd15a1476a44" />


### 아직 안 한 거
- 위쪽 안내 & 공유 배너
	- overlay 먼저 해야될 거 같아서 따로 분기 할 예정
- 중간 캐러셀 컨텐츠
	- 아직 디자인이 완전 확정 안 난거 같아서 보류